### PR TITLE
feat: Allow manual override of unit price in new sales

### DIFF
--- a/app/sales/new/page.tsx
+++ b/app/sales/new/page.tsx
@@ -130,7 +130,7 @@ export default function NewSalePage() {
     const perfume = perfumes.find((p) => p.id === Number.parseInt(currentItem.perfumeId))
     if (!perfume || !currentItem.bottleType || !currentItem.milliliters) return
 
-    const unitPrice = calculateItemPrice()
+    const unitPrice = currentItem.price ? Number.parseFloat(currentItem.price) : calculateItemPrice()
     const quantity = Number.parseInt(currentItem.quantity)
     const totalMl = Number.parseInt(currentItem.milliliters) * quantity
     const alcoholMlCount= flasks.find((flask) =>  flask.id === Number.parseInt(currentItem.bottleType)).alcohol_ml || 0


### PR DESCRIPTION
This change modifies the new sale page to allow the user to manually enter a unit price for a sale item, overriding the automatically calculated price. The logic in the `addItemToSale` function is updated to prioritize the user-entered price.